### PR TITLE
fix(test): strip quotes from CMD args on Windows

### DIFF
--- a/tests/cli-smoke.rs
+++ b/tests/cli-smoke.rs
@@ -293,11 +293,11 @@ fn fake_opensrc(temp: &TempDir, script: &str) -> PathBuf {
 fn successful_opensrc_script() -> &'static str {
     if cfg!(windows) {
         r#"@echo off
-if not "%1"=="path" exit /b 11
-if not "%2"=="--cwd" exit /b 12
-if not "%3"=="%GITQUARRY_FAKE_CWD%" exit /b 13
-if not "%4"=="--verbose" exit /b 14
-if not "%5"=="%GITQUARRY_FAKE_SPEC%" exit /b 15
+if not "%~1"=="path" exit /b 11
+if not "%~2"=="--cwd" exit /b 12
+if not "%~3"=="%GITQUARRY_FAKE_CWD%" exit /b 13
+if not "%~4"=="--verbose" exit /b 14
+if not "%~5"=="%GITQUARRY_FAKE_SPEC%" exit /b 15
 echo fetching fixture 1>&2
 echo %GITQUARRY_FAKE_PATH%
 "#


### PR DESCRIPTION
## Problem
Windows CI fails in `source_path_delegates_to_opensrc_and_prints_path_only` with exit code 13.

Rust's `Command::arg()` wraps arguments containing spaces in double quotes on Windows. The batch fake `opensrc.cmd` received quoted values via `%N` but compared them against unquoted env vars (`%GITQUARRY_FAKE_CWD%`), causing a mismatch.

## Fix
Use `%~N` (tilde modifier) in the batch script to strip surrounding quotes from arguments before comparison.

Closes CI failure on windows-latest.