### PR TITLE
feat: add remote tree and code search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is intentionally simple and does not depend on a release tool.
 
 ## Unreleased
 
+## [0.1.7]
+
+- Add `gitquarry tree` for no-clone repository tree inspection with path glob, text, depth, ref, and structured output controls
+- Add `gitquarry code` for no-clone repository code search with literal or regex matching, path filters, context lines, limits, and structured output
+- Document tree and code commands for CLI, MCP, and agent workflows
+
 ## [0.1.6]
 
 - Keep GitHub release publishing green when npm registry permissions reject wrapper publish

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -489,7 +489,7 @@ dependencies = [
 
 [[package]]
 name = "gitquarry"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "anstream 0.6.21",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gitquarry"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2024"
 rust-version = "1.85"
 authors = ["Microck <contact@micr.dev>"]

--- a/README.md
+++ b/README.md
@@ -159,6 +159,8 @@ for a GitHub Enterprise host, gitquarry derives the env var name from the normal
 | --- | --- |
 | `gitquarry search` | search public repositories with native mode by default and explicit discover mode when requested |
 | `gitquarry inspect` | inspect one explicit `owner/repo` with optional README inclusion |
+| `gitquarry tree` | print a repository file tree from GitHub without cloning |
+| `gitquarry code` | search repository file contents from GitHub without cloning |
 | `gitquarry source` | fetch or locate source code through `opensrc` when explicitly requested |
 | `gitquarry auth` | save, inspect, and remove host-scoped personal access tokens |
 | `gitquarry config` | print the effective config path or effective config payload |
@@ -178,6 +180,8 @@ root commands:
 ```bash
 gitquarry search [OPTIONS] [QUERY]
 gitquarry inspect [OPTIONS] <OWNER/REPO>
+gitquarry tree [OPTIONS] <OWNER/REPO>
+gitquarry code [OPTIONS] <OWNER/REPO> <PATTERN>
 gitquarry source path [OPTIONS] <SPEC>
 gitquarry auth login|status|logout
 gitquarry config path|show
@@ -200,6 +204,22 @@ inspect-specific controls stay intentionally narrow:
 - `--readme`
 - `--format pretty|json|compact|csv`
 - `--progress auto|on|off`
+
+tree-specific controls inspect remote repository paths without cloning:
+
+- `--reference <REF>`
+- `--path <GLOB>` for `*` and `?` path matching
+- `--contains <TEXT>`
+- `--depth <N>`
+
+code-specific controls search remote file contents without cloning:
+
+- `--reference <REF>`
+- `--path <GLOB>` for candidate file filtering
+- `--mode literal|regex`
+- `--context <N>`
+- `--limit <N>`
+- `--max-file-bytes <BYTES>`
 
 source-specific controls are explicit and delegated to `opensrc`:
 
@@ -301,6 +321,18 @@ gitquarry source path rust-lang/rust
 rg "fn main" "$(gitquarry source path rust-lang/rust)"
 ```
 
+inspect a repository tree without cloning:
+
+```bash
+gitquarry tree rust-lang/rust --path "src/*.rs" --depth 2
+```
+
+search remote code without cloning:
+
+```bash
+gitquarry code rust-lang/rust "fn main" --path "src/*.rs" --context 2
+```
+
 pipe structured output without polluting stdout with progress:
 
 ```bash
@@ -357,6 +389,9 @@ Usage: gitquarry [OPTIONS] [COMMAND]
 Commands:
   search   Search public repositories
   inspect  Inspect one explicit owner/repo
+  tree     Print a repository file tree without cloning it
+  code     Search repository code without cloning it
+  source   Fetch or locate source code through opensrc
   auth     Manage host-scoped personal access tokens
   config   Show config path or the effective config payload
   version  Print the current gitquarry version
@@ -416,6 +451,8 @@ for the fuller install matrix and release operations, use the [installation guid
 - [discovery mode guide](./docs/guides/discovery-mode.mdx)
 - [search command reference](./docs/commands/search.mdx)
 - [inspect command reference](./docs/commands/inspect.mdx)
+- [tree command reference](./docs/commands/tree.mdx)
+- [code command reference](./docs/commands/code.mdx)
 - [source command reference](./docs/commands/source.mdx)
 - [auth command reference](./docs/commands/auth.mdx)
 - [config command reference](./docs/commands/config.mdx)

--- a/docs/commands/code.mdx
+++ b/docs/commands/code.mdx
@@ -1,0 +1,56 @@
+---
+title: "code"
+description: "Reference for gitquarry code, the no-clone repository code search command."
+---
+
+# `gitquarry code`
+
+Search repository file contents from GitHub without cloning the repository.
+
+## Synopsis
+
+```bash
+gitquarry code [OPTIONS] <OWNER/REPO> <PATTERN>
+```
+
+## Behavior
+
+`code` first fetches the repository tree, filters candidate blobs, then fetches matching file contents through the GitHub API.
+
+Use `--path`, `--limit`, and `--max-file-bytes` to keep broad searches bounded. Files that cannot be decoded as UTF-8 text are skipped.
+
+## Options
+
+```bash
+--reference <REF>
+--path <GLOB>
+--mode literal|regex
+--context <N>
+--limit <N>
+--max-file-bytes <BYTES>
+--format pretty|json|compact|csv
+--progress auto|on|off
+```
+
+`--path` can be repeated. Repeated patterns use OR semantics.
+
+## Examples
+
+Search for literal text:
+
+```bash
+gitquarry code rust-lang/rust "fn main" --path "src/*.rs"
+```
+
+Search with a regex and context:
+
+```bash
+gitquarry code rust-lang/rust "pub fn [a-z_]+" --mode regex --context 2
+```
+
+Use structured output for automation:
+
+```bash
+gitquarry code rust-lang/rust "HashMap" --path "compiler/*.rs" --format json
+```
+

--- a/docs/commands/tree.mdx
+++ b/docs/commands/tree.mdx
@@ -1,0 +1,64 @@
+---
+title: "tree"
+description: "Reference for gitquarry tree, the no-clone repository tree inspection command."
+---
+
+# `gitquarry tree`
+
+Print a repository file tree from GitHub without cloning the repository.
+
+## Synopsis
+
+```bash
+gitquarry tree [OPTIONS] <OWNER/REPO>
+```
+
+## Behavior
+
+`tree` fetches the repository tree through the GitHub API. By default it uses the repository default branch.
+
+The output can be filtered before rendering:
+
+- `--path` accepts simple glob patterns using `*` and `?`
+- `--contains` keeps paths containing a text fragment
+- `--depth` limits displayed path depth, where root entries are depth `1`
+
+## Options
+
+```bash
+--reference <REF>
+--path <GLOB>
+--contains <TEXT>
+--depth <N>
+--format pretty|json|compact|csv
+--progress auto|on|off
+```
+
+`--path` can be repeated. Repeated patterns use OR semantics.
+
+## Examples
+
+Print the full tree:
+
+```bash
+gitquarry tree rust-lang/rust
+```
+
+Show Rust files below `src`:
+
+```bash
+gitquarry tree rust-lang/rust --path "src/*.rs"
+```
+
+Limit visible depth:
+
+```bash
+gitquarry tree rust-lang/rust --depth 2
+```
+
+Use a specific ref and structured output:
+
+```bash
+gitquarry tree rust-lang/rust --reference master --format json
+```
+

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -94,6 +94,8 @@
             "pages": [
               "commands/search",
               "commands/inspect",
+              "commands/tree",
+              "commands/code",
               "commands/source",
               "commands/auth",
               "commands/config"

--- a/docs/reference/cli-overview.mdx
+++ b/docs/reference/cli-overview.mdx
@@ -12,6 +12,8 @@ Gitquarry has a deliberately small root command surface.
 ```bash
 gitquarry search [OPTIONS] [QUERY]
 gitquarry inspect [OPTIONS] <OWNER/REPO>
+gitquarry tree [OPTIONS] <OWNER/REPO>
+gitquarry code [OPTIONS] <OWNER/REPO> <PATTERN>
 gitquarry source path [OPTIONS] <SPEC>
 gitquarry auth login|status|logout
 gitquarry config path|show
@@ -56,6 +58,8 @@ Supported values:
 | --- | --- |
 | `search` | repository discovery and ranking |
 | `inspect` | explicit `owner/repo` inspection |
+| `tree` | no-clone repository tree inspection |
+| `code` | no-clone repository file content search |
 | `source` | explicit opensrc-backed source retrieval |
 | `auth` | host-scoped PAT management |
 | `config` | inspect effective config path and payload |
@@ -67,6 +71,7 @@ The most important root-level rule is:
 
 - plain `search` stays close to native GitHub repository search
 - enhanced discovery stays explicit
+- remote tree and code inspection do not clone repositories
 - source fetching stays explicit through `source path`
 
 That contract is defined in [Search Behavior](/reference/search-behavior) and the repo spec.

--- a/docs/reference/output-schemas.mdx
+++ b/docs/reference/output-schemas.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Output Schemas"
-description: "See the exact JSON and CSV output shapes used by gitquarry search and inspect."
+description: "See the exact JSON and CSV output shapes used by gitquarry search, inspect, tree, and code."
 ---
 
 # Output Schemas
@@ -73,6 +73,59 @@ Each item uses the repository schema:
 }
 ```
 
+## Tree JSON Shape
+
+`gitquarry tree --format json` serializes this top-level shape:
+
+```json
+{
+  "host": "github.com",
+  "repository": "Microck/gitquarry",
+  "reference": "main",
+  "truncated": false,
+  "total_count": 3,
+  "items": [
+    {
+      "path": "src/main.rs",
+      "kind": "Blob",
+      "size": 1234
+    }
+  ]
+}
+```
+
+`kind` is one of `Blob`, `Tree`, or `Commit`.
+
+## Code JSON Shape
+
+`gitquarry code --format json` serializes this top-level shape:
+
+```json
+{
+  "host": "github.com",
+  "repository": "Microck/gitquarry",
+  "reference": "main",
+  "pattern": "fn main",
+  "mode": "literal",
+  "searched_files": 1,
+  "skipped_files": 0,
+  "total_count": 1,
+  "items": [
+    {
+      "path": "src/main.rs",
+      "line": 3,
+      "lines": [
+        {
+          "line": 3,
+          "text": "fn main() {",
+          "matched": true
+        }
+      ]
+    }
+  ]
+}
+```
+
 ## Explain Object
 
 When `--explain` is active in enhanced flows, `repository.explain` can include:
@@ -94,7 +147,7 @@ When `--explain` is active in enhanced flows, `repository.explain` can include:
 
 ## CSV Columns
 
-CSV output always writes this header:
+`search` and `inspect` CSV output write this header:
 
 ```text
 full_name,html_url,description,stars,forks,language,topics,license,created_at,updated_at,pushed_at,archived,template,fork,open_issues_count,contributor_count,query_score,activity_score,quality_score,blended_score
@@ -106,6 +159,8 @@ Notes:
 - timestamps are RFC3339 in CSV
 - score columns are `0` when no explain data is present
 - `inspect --format csv` writes one row
+- `tree --format csv` writes `path,type,size`
+- `code --format csv` writes `path,line,text`
 
 ## Pretty Output
 
@@ -130,3 +185,7 @@ Pretty output is for humans, not strict parsing.
 - open issue count
 - latest release when available
 - README block when requested
+
+`tree --format pretty` prints repository/ref metadata and an indented file tree.
+
+`code --format pretty` prints match counts, file paths, line numbers, and requested context lines.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -8,7 +8,7 @@
 - Primary language: Rust
 - Canonical docs: https://gitquarry.micr.dev/
 - Source repo: https://github.com/Microck/gitquarry
-- Main commands: `search`, `inspect`, `auth`, `config`, `version`
+- Main commands: `search`, `inspect`, `tree`, `code`, `source`, `auth`, `config`, `version`
 - Install surfaces: npm, Homebrew, Scoop, AUR, GitHub Releases, Nix, source build
 - Auth model: PAT-only in v1, host-scoped, secure storage first, explicit insecure fallback only
 - Output contract: `pretty`, `json`, `compact`, `csv`; progress on `stderr`; errors are symbolic plain text
@@ -31,6 +31,8 @@
 
 - [search](https://gitquarry.micr.dev/commands/search): Search public repositories. Supports native mode by default and explicit discover mode with alternative rank strategies.
 - [inspect](https://gitquarry.micr.dev/commands/inspect): Inspect a single explicit `owner/repo`. Optional README inclusion. Metadata-first by default.
+- [tree](https://gitquarry.micr.dev/commands/tree): Inspect a repository tree through GitHub without cloning. Supports path glob filters, text containment, depth limits, refs, and structured output.
+- [code](https://gitquarry.micr.dev/commands/code): Search repository file contents through GitHub without cloning. Supports literal or regex search, path filters, context lines, match limits, refs, and structured output.
 - [auth](https://gitquarry.micr.dev/commands/auth): Manage host-scoped personal access tokens through `login`, `status`, and `logout`.
 - [config](https://gitquarry.micr.dev/commands/config): Print the effective config path and the effective config payload.
 

--- a/llms.txt
+++ b/llms.txt
@@ -27,6 +27,8 @@
 
 - [search](https://gitquarry.micr.dev/commands/search): Primary repository search command with native and discover modes.
 - [inspect](https://gitquarry.micr.dev/commands/inspect): Explicit `owner/repo` inspection with optional README inclusion.
+- [tree](https://gitquarry.micr.dev/commands/tree): No-clone repository tree inspection with glob, text, depth, ref, and structured output controls.
+- [code](https://gitquarry.micr.dev/commands/code): No-clone repository code search with path filters, literal or regex matching, context, and structured output.
 - [auth](https://gitquarry.micr.dev/commands/auth): Host-scoped PAT login, status, and logout.
 - [config](https://gitquarry.micr.dev/commands/config): Effective config path and config payload inspection.
 
@@ -36,7 +38,7 @@
 - [Config And Credentials](https://gitquarry.micr.dev/reference/config-and-credentials): Config fields, `GITQUARRY_CONFIG_DIR`, token precedence, and auth storage rules.
 - [Engine Internals](https://gitquarry.micr.dev/reference/engine-internals): Native search, discover expansion, retries, scoring, and README window behavior.
 - [Output Contract](https://gitquarry.micr.dev/reference/output-contract): stdout vs stderr rules and scripting guarantees.
-- [Output Schemas](https://gitquarry.micr.dev/reference/output-schemas): Exact JSON and CSV shapes for `search` and `inspect`.
+- [Output Schemas](https://gitquarry.micr.dev/reference/output-schemas): Exact JSON and CSV shapes for `search`, `inspect`, `tree`, and `code`.
 - [Error Reference](https://gitquarry.micr.dev/reference/error-reference): Stable error codes and typical fixes.
 - [Search Behavior](https://gitquarry.micr.dev/reference/search-behavior): Behavioral contract for native vs discover semantics.
 - [Specification](https://gitquarry.micr.dev/project/specification): Full product contract for command surface, validation, ranking, output, and error semantics.

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitquarry",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Node wrapper that installs the native gitquarry CLI binary",
   "license": "MIT",
   "repository": {

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gitquarry-operator
-description: Operate gitquarry correctly for GitHub repository search, inspection, authentication, host selection, and script-safe output. Use when running gitquarry commands, choosing between native and discover search, selecting rank, depth, README, explain, format, progress, host, or config options, troubleshooting auth or flag conflicts, or producing operator-ready gitquarry command lines.
+description: Operate gitquarry correctly for GitHub repository search, inspection, remote tree/code lookup, authentication, host selection, and script-safe output. Use when running gitquarry commands, choosing between native and discover search, selecting rank, depth, README, explain, tree/code path filters, format, progress, host, or config options, troubleshooting auth or flag conflicts, or producing operator-ready gitquarry command lines.
 ---
 
 # Gitquarry Operator
@@ -9,7 +9,7 @@ Use this skill to drive `gitquarry` as a tool, not just to pick one benchmarked 
 
 ## Workflow
 
-1. Classify the task as `auth`, `search`, `inspect`, `config`, or scripting.
+1. Classify the task as `auth`, `search`, `inspect`, `tree`, `code`, `config`, or scripting.
 2. Verify the effective host before assuming credentials or config state.
 3. Start with the narrowest command that solves the task.
 4. Prefer native `search` first. Turn on discover mode only when the request actually needs broader coverage, reranking, README evidence, or explain output.
@@ -22,7 +22,17 @@ Use this skill to drive `gitquarry` as a tool, not just to pick one benchmarked 
 - Use `gitquarry auth login|status|logout` for credential work.
 - Use `gitquarry search` for repository discovery and ranking.
 - Use `gitquarry inspect <owner/repo>` when the target repository is already known.
+- Use `gitquarry tree <owner/repo>` when the task needs repository paths without cloning.
+- Use `gitquarry code <owner/repo> <pattern>` when the task needs remote code search without cloning.
 - Use `gitquarry config path|show` when the task is about effective config state.
+
+## Tree And Code Rules
+
+- Prefer `tree` over `source path` when path inspection is enough and no local checkout is needed.
+- Prefer `code` over `source path` for bounded literal or regex code search inside one known repository.
+- Add `--path` filters, `--depth`, `--limit`, or `--max-file-bytes` when a broad remote scan could be noisy or API-heavy.
+- Use `--reference` when a branch, tag, or commit matters.
+- Use `--mode regex` only when regex semantics are required; literal search is the default.
 
 ## Search Rules
 
@@ -54,6 +64,7 @@ Use this skill to drive `gitquarry` as a tool, not just to pick one benchmarked 
 - If a discover-only flag is used without `--mode discover`, fix the command instead of guessing around the error.
 - If a raw query qualifier conflicts with a structured flag, remove one side of the conflict.
 - If `inspect` input is not `owner/repo`, correct the repository shape before auth debugging.
+- If `tree` or `code` is too broad, narrow with `--path`, `--depth`, or `--limit` before escalating to `source path`.
 - If auth fails, verify token, host, and resolution order before changing search flags.
 
 ## References
@@ -63,6 +74,8 @@ Read these only when needed:
 - `references/benchmark-operator-playbook.md` for the full operator playbook, command patterns, host/auth/scripting rules, and benchmark-backed discover heuristics.
 - `../docs/commands/search.mdx` when exact search flag behavior matters.
 - `../docs/commands/inspect.mdx` when the task is repository inspection rather than search.
+- `../docs/commands/tree.mdx` when the task is remote repository tree inspection.
+- `../docs/commands/code.mdx` when the task is no-clone code search.
 - `../docs/guides/output-and-scripting.mdx` when the task is CI, pipeline, or agent-safe usage.
 - `../docs/guides/github-enterprise-hosts.mdx` when the task involves non-default hosts.
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,6 +1,6 @@
 use crate::cli::{
-    AuthArgs, AuthCommand, AuthLoginArgs, Cli, Command, ConfigArgs, ConfigCommand, InspectArgs,
-    SearchArgs, SourceArgs, SourceCommand,
+    AuthArgs, AuthCommand, AuthLoginArgs, Cli, CodeArgs, Command, ConfigArgs, ConfigCommand,
+    InspectArgs, SearchArgs, SourceArgs, SourceCommand, TreeArgs,
 };
 use crate::config::ConfigBundle;
 use crate::credential::{
@@ -10,10 +10,13 @@ use crate::error::{AppError, AppResult};
 use crate::github::GitHubClient;
 use crate::host::{HostContext, normalize_host};
 use crate::model::{
-    ColorPreference, CredentialSource, InspectOutput, OutputFormat, ProgressMode, RankMode,
-    Repository, RetrievalMode, SearchOutput, SearchSort,
+    CodeMatch, CodeMatchLine, CodeSearchOutput, ColorPreference, CredentialSource, InspectOutput,
+    OutputFormat, ProgressMode, RankMode, Repository, RetrievalMode, SearchOutput,
+    SearchPatternMode, SearchSort, TreeEntry, TreeEntryKind, TreeOutput,
 };
-use crate::output::{progress, write_inspect, write_line, write_search};
+use crate::output::{
+    progress, write_code_search, write_inspect, write_line, write_search, write_tree,
+};
 use crate::query::{
     apply_post_filters, build_search_plan, compiled_query_has_qualifier, discovery_target,
 };
@@ -22,6 +25,7 @@ use chrono::{Duration, Utc};
 use clap::{CommandFactory, Parser, error::ErrorKind};
 use clap_complete::generate;
 use rayon::prelude::*;
+use regex::Regex;
 use std::collections::HashMap;
 use std::io::{self, IsTerminal, Read, Write};
 use std::process::exit;
@@ -71,6 +75,8 @@ fn run() -> AppResult<()> {
     match &cli.command {
         Some(Command::Search(args)) => search_command(&cli, &config, args),
         Some(Command::Inspect(args)) => inspect_command(&cli, &config, args),
+        Some(Command::Tree(args)) => tree_command(&cli, &config, args),
+        Some(Command::Code(args)) => code_command(&cli, &config, args),
         Some(Command::Source(args)) => source_command(args),
         Some(Command::Auth(args)) => auth_command(&cli, &config, args),
         Some(Command::Config(args)) => config_command(&config, args),
@@ -236,6 +242,110 @@ fn inspect_command(cli: &Cli, config: &ConfigBundle, args: &InspectArgs) -> AppR
     )
 }
 
+fn tree_command(cli: &Cli, config: &ConfigBundle, args: &TreeArgs) -> AppResult<()> {
+    let host = resolve_host(cli, config)?;
+    let show_progress = progress_enabled(
+        args.progress
+            .unwrap_or(config.data.progress.unwrap_or(ProgressMode::Auto)),
+    );
+    let (owner, repo) = parse_owner_repo(&args.repository)?;
+    let token = resolve_token(&host, config)?;
+    let client = GitHubClient::new(host.api_base.clone(), token.token)?;
+    let reference = resolve_reference(&client, &owner, &repo, args.reference.as_deref())?;
+    progress(
+        show_progress,
+        format!("fetching tree {owner}/{repo}@{reference}"),
+    );
+    let tree = client.repository_tree(&owner, &repo, &reference)?;
+    let items = filter_tree_entries(
+        tree.entries,
+        args.depth,
+        &args.paths,
+        args.contains.as_deref(),
+    )?;
+    let output = TreeOutput {
+        host: host.web_host,
+        repository: args.repository.clone(),
+        reference: tree.reference,
+        truncated: tree.truncated,
+        total_count: items.len(),
+        items,
+    };
+    write_tree(
+        &output,
+        args.format
+            .unwrap_or(config.data.format.unwrap_or(OutputFormat::Pretty)),
+        config.data.color.unwrap_or(ColorPreference::Auto),
+    )
+}
+
+fn code_command(cli: &Cli, config: &ConfigBundle, args: &CodeArgs) -> AppResult<()> {
+    if args.limit == 0 {
+        return Err(AppError::new(
+            "E_FLAG_CONFLICT",
+            "--limit must be greater than 0",
+        ));
+    }
+    let host = resolve_host(cli, config)?;
+    let show_progress = progress_enabled(
+        args.progress
+            .unwrap_or(config.data.progress.unwrap_or(ProgressMode::Auto)),
+    );
+    let (owner, repo) = parse_owner_repo(&args.repository)?;
+    let token = resolve_token(&host, config)?;
+    let client = GitHubClient::new(host.api_base.clone(), token.token)?;
+    let reference = resolve_reference(&client, &owner, &repo, args.reference.as_deref())?;
+    progress(
+        show_progress,
+        format!("fetching tree {owner}/{repo}@{reference}"),
+    );
+    let tree = client.repository_tree(&owner, &repo, &reference)?;
+    let files = candidate_code_files(tree.entries, &args.paths, args.max_file_bytes)?;
+    let matcher = PatternMatcher::new(&args.pattern, args.mode)?;
+    let mut matches = Vec::new();
+    let mut searched_files = 0usize;
+    let mut skipped_files = 0usize;
+
+    for file in files {
+        if matches.len() >= args.limit {
+            break;
+        }
+        progress(show_progress, format!("searching {}", file.path));
+        match client.file_text(&owner, &repo, &file.path, &reference)? {
+            Some(text) => {
+                searched_files += 1;
+                append_code_matches(
+                    &mut matches,
+                    &file.path,
+                    &text,
+                    &matcher,
+                    args.context,
+                    args.limit,
+                );
+            }
+            None => skipped_files += 1,
+        }
+    }
+
+    let output = CodeSearchOutput {
+        host: host.web_host,
+        repository: args.repository.clone(),
+        reference,
+        pattern: args.pattern.clone(),
+        mode: args.mode,
+        searched_files,
+        skipped_files,
+        total_count: matches.len(),
+        items: matches,
+    };
+    write_code_search(
+        &output,
+        args.format
+            .unwrap_or(config.data.format.unwrap_or(OutputFormat::Pretty)),
+        config.data.color.unwrap_or(ColorPreference::Auto),
+    )
+}
+
 fn auth_command(cli: &Cli, config: &ConfigBundle, args: &AuthArgs) -> AppResult<()> {
     let host = resolve_host(cli, config)?;
     match &args.command {
@@ -376,6 +486,141 @@ fn progress_enabled(mode: ProgressMode) -> bool {
         ProgressMode::On => true,
         ProgressMode::Off => false,
         ProgressMode::Auto => io::stderr().is_terminal(),
+    }
+}
+
+fn resolve_reference(
+    client: &GitHubClient,
+    owner: &str,
+    repo: &str,
+    requested: Option<&str>,
+) -> AppResult<String> {
+    if let Some(reference) = requested
+        && !reference.trim().is_empty()
+    {
+        return Ok(reference.trim().to_string());
+    }
+    client.default_branch(owner, repo)
+}
+
+fn filter_tree_entries(
+    entries: Vec<TreeEntry>,
+    depth: Option<usize>,
+    path_patterns: &[String],
+    contains: Option<&str>,
+) -> AppResult<Vec<TreeEntry>> {
+    let matchers = compile_globs(path_patterns)?;
+    Ok(entries
+        .into_iter()
+        .filter(|entry| {
+            depth.is_none_or(|max_depth| path_depth(&entry.path) <= max_depth)
+                && contains.is_none_or(|needle| entry.path.contains(needle))
+                && (matchers.is_empty()
+                    || matchers.iter().any(|matcher| matcher.is_match(&entry.path)))
+        })
+        .collect())
+}
+
+fn candidate_code_files(
+    entries: Vec<TreeEntry>,
+    path_patterns: &[String],
+    max_file_bytes: u64,
+) -> AppResult<Vec<TreeEntry>> {
+    let matchers = compile_globs(path_patterns)?;
+    Ok(entries
+        .into_iter()
+        .filter(|entry| entry.kind == TreeEntryKind::Blob)
+        .filter(|entry| entry.size.is_none_or(|size| size <= max_file_bytes))
+        .filter(|entry| {
+            matchers.is_empty() || matchers.iter().any(|matcher| matcher.is_match(&entry.path))
+        })
+        .collect())
+}
+
+fn path_depth(path: &str) -> usize {
+    path.split('/').filter(|part| !part.is_empty()).count()
+}
+
+fn compile_globs(patterns: &[String]) -> AppResult<Vec<Regex>> {
+    patterns
+        .iter()
+        .map(|pattern| {
+            Regex::new(&glob_to_regex(pattern)).map_err(|err| {
+                AppError::with_detail("E_FLAG_CONFLICT", "invalid path glob", err.to_string())
+            })
+        })
+        .collect()
+}
+
+fn glob_to_regex(pattern: &str) -> String {
+    let mut raw = String::from("^");
+    for ch in pattern.chars() {
+        match ch {
+            '*' => raw.push_str("[^/]*"),
+            '?' => raw.push_str("[^/]"),
+            '.' | '+' | '(' | ')' | '|' | '^' | '$' | '{' | '}' | '[' | ']' | '\\' => {
+                raw.push('\\');
+                raw.push(ch);
+            }
+            _ => raw.push(ch),
+        }
+    }
+    raw.push('$');
+    raw
+}
+
+enum PatternMatcher {
+    Literal(String),
+    Regex(Regex),
+}
+
+impl PatternMatcher {
+    fn new(pattern: &str, mode: SearchPatternMode) -> AppResult<Self> {
+        match mode {
+            SearchPatternMode::Literal => Ok(Self::Literal(pattern.to_string())),
+            SearchPatternMode::Regex => Regex::new(pattern).map(Self::Regex).map_err(|err| {
+                AppError::with_detail("E_FLAG_CONFLICT", "invalid regex pattern", err.to_string())
+            }),
+        }
+    }
+
+    fn is_match(&self, line: &str) -> bool {
+        match self {
+            Self::Literal(pattern) => line.contains(pattern),
+            Self::Regex(pattern) => pattern.is_match(line),
+        }
+    }
+}
+
+fn append_code_matches(
+    matches: &mut Vec<CodeMatch>,
+    path: &str,
+    text: &str,
+    matcher: &PatternMatcher,
+    context: usize,
+    limit: usize,
+) {
+    let lines = text.lines().collect::<Vec<_>>();
+    for (index, line) in lines.iter().enumerate() {
+        if matches.len() >= limit {
+            break;
+        }
+        if !matcher.is_match(line) {
+            continue;
+        }
+        let start = index.saturating_sub(context);
+        let end = (index + context + 1).min(lines.len());
+        matches.push(CodeMatch {
+            path: path.to_string(),
+            line: index + 1,
+            lines: (start..end)
+                .map(|line_index| CodeMatchLine {
+                    line: line_index + 1,
+                    text: lines[line_index].to_string(),
+                    matched: line_index == index,
+                })
+                .collect(),
+        });
     }
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,6 +1,6 @@
 use crate::model::{
     BoolFlag, DiscoveryDepth, ForkMode, OutputFormat, ProgressMode, RankMode, RetrievalMode,
-    SearchSort,
+    SearchPatternMode, SearchSort,
 };
 use clap::{Args, Parser, Subcommand, ValueEnum};
 use clap_complete::Shell;
@@ -51,6 +51,10 @@ pub enum Command {
     Search(Box<SearchArgs>),
     /// Inspect one explicit owner/repo.
     Inspect(InspectArgs),
+    /// Print a repository file tree without cloning it.
+    Tree(TreeArgs),
+    /// Search repository code without cloning it.
+    Code(CodeArgs),
     /// Fetch or locate source code through opensrc.
     Source(SourceArgs),
     /// Manage host-scoped personal access tokens.
@@ -219,6 +223,77 @@ pub struct InspectArgs {
     /// Include the repository README in the output.
     #[arg(long, default_value_t = false)]
     pub readme: bool,
+
+    /// Output format.
+    #[arg(long, value_enum)]
+    pub format: Option<OutputFormat>,
+
+    /// Progress output mode for stderr.
+    #[arg(long, value_enum)]
+    pub progress: Option<ProgressMode>,
+}
+
+#[derive(Debug, Args, Clone)]
+pub struct TreeArgs {
+    /// Explicit repository identifier in owner/repo form.
+    pub repository: String,
+
+    /// Git ref to inspect. Defaults to the repository default branch.
+    #[arg(long)]
+    pub reference: Option<String>,
+
+    /// Only show paths matching this glob pattern. Repeat for OR semantics.
+    #[arg(long = "path")]
+    pub paths: Vec<String>,
+
+    /// Only show paths containing this text.
+    #[arg(long)]
+    pub contains: Option<String>,
+
+    /// Maximum path depth to print, where root entries are depth 1.
+    #[arg(long)]
+    pub depth: Option<usize>,
+
+    /// Output format.
+    #[arg(long, value_enum)]
+    pub format: Option<OutputFormat>,
+
+    /// Progress output mode for stderr.
+    #[arg(long, value_enum)]
+    pub progress: Option<ProgressMode>,
+}
+
+#[derive(Debug, Args, Clone)]
+pub struct CodeArgs {
+    /// Explicit repository identifier in owner/repo form.
+    pub repository: String,
+
+    /// Text or regex pattern to search for.
+    pub pattern: String,
+
+    /// Git ref to inspect. Defaults to the repository default branch.
+    #[arg(long)]
+    pub reference: Option<String>,
+
+    /// Restrict searched files to this glob pattern. Repeat for OR semantics.
+    #[arg(long = "path")]
+    pub paths: Vec<String>,
+
+    /// Treat the pattern as literal text or a Rust regex.
+    #[arg(long, value_enum, default_value_t = SearchPatternMode::Literal)]
+    pub mode: SearchPatternMode,
+
+    /// Lines of context to include before and after each match.
+    #[arg(long, default_value_t = 0)]
+    pub context: usize,
+
+    /// Maximum number of matches to print.
+    #[arg(long, default_value_t = 100)]
+    pub limit: usize,
+
+    /// Maximum file size to fetch in bytes.
+    #[arg(long, default_value_t = 1_000_000)]
+    pub max_file_bytes: u64,
 
     /// Output format.
     #[arg(long, value_enum)]

--- a/src/github.rs
+++ b/src/github.rs
@@ -1,5 +1,6 @@
 use crate::error::{AppError, AppResult};
-use crate::model::{LicenseInfo, ReleaseSummary, Repository};
+use crate::model::{LicenseInfo, ReleaseSummary, Repository, TreeEntry, TreeEntryKind};
+use base64::Engine;
 use chrono::{DateTime, Utc};
 use reqwest::StatusCode;
 use reqwest::blocking::{Client, Response};
@@ -26,6 +27,13 @@ pub struct SearchPage {
 #[derive(Debug, Clone)]
 pub struct AuthIdentity {
     pub login: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct RepositoryTree {
+    pub reference: String,
+    pub truncated: bool,
+    pub entries: Vec<TreeEntry>,
 }
 
 impl GitHubClient {
@@ -105,6 +113,83 @@ impl GitHubClient {
         })?;
         let payload: RepositoryResponse = parse_json(response)?;
         Ok(payload.into())
+    }
+
+    pub fn default_branch(&self, owner: &str, repo: &str) -> AppResult<String> {
+        let response = self.send_with_retry(|| {
+            self.http
+                .get(format!("{}/repos/{owner}/{repo}", self.api_base))
+        })?;
+        let payload: RepositoryMetadataResponse = parse_json(response)?;
+        Ok(payload.default_branch)
+    }
+
+    pub fn repository_tree(
+        &self,
+        owner: &str,
+        repo: &str,
+        reference: &str,
+    ) -> AppResult<RepositoryTree> {
+        let response = self.send_with_retry(|| {
+            self.http
+                .get(format!(
+                    "{}/repos/{owner}/{repo}/git/trees/{reference}",
+                    self.api_base
+                ))
+                .query(&[("recursive", "1")])
+        })?;
+        let payload: TreeResponse = parse_json(response)?;
+        Ok(RepositoryTree {
+            reference: reference.to_string(),
+            truncated: payload.truncated,
+            entries: payload
+                .tree
+                .into_iter()
+                .filter_map(|entry| TreeEntry::try_from(entry).ok())
+                .collect(),
+        })
+    }
+
+    pub fn file_text(
+        &self,
+        owner: &str,
+        repo: &str,
+        path: &str,
+        reference: &str,
+    ) -> AppResult<Option<String>> {
+        let response = self.send_with_retry(|| {
+            self.http
+                .get(format!(
+                    "{}/repos/{owner}/{repo}/contents/{path}",
+                    self.api_base
+                ))
+                .query(&[("ref", reference)])
+        });
+
+        let response = match response {
+            Ok(response) => response,
+            Err(error) if error.code == "E_NOT_FOUND" => return Ok(None),
+            Err(error) => return Err(error),
+        };
+
+        let payload: ContentResponse = parse_json(response)?;
+        let Some(content) = payload.content else {
+            return Ok(None);
+        };
+        if payload.encoding.as_deref() != Some("base64") {
+            return Ok(None);
+        }
+
+        let compact = content.lines().collect::<String>();
+        let bytes = base64::engine::general_purpose::STANDARD
+            .decode(compact)
+            .map_err(|err| {
+                AppError::with_detail("E_HTTP", "failed to decode file content", err.to_string())
+            })?;
+        match String::from_utf8(bytes) {
+            Ok(text) => Ok(Some(text)),
+            Err(_) => Ok(None),
+        }
     }
 
     pub fn readme(&self, owner: &str, repo: &str) -> AppResult<Option<String>> {
@@ -328,6 +413,51 @@ struct AuthUser {
 struct SearchResponse {
     total_count: usize,
     items: Vec<RepositoryResponse>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RepositoryMetadataResponse {
+    default_branch: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct TreeResponse {
+    #[serde(default)]
+    tree: Vec<TreeEntryResponse>,
+    #[serde(default)]
+    truncated: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct TreeEntryResponse {
+    path: String,
+    #[serde(rename = "type")]
+    kind: String,
+    size: Option<u64>,
+}
+
+impl TryFrom<TreeEntryResponse> for TreeEntry {
+    type Error = ();
+
+    fn try_from(value: TreeEntryResponse) -> Result<Self, Self::Error> {
+        let kind = match value.kind.as_str() {
+            "blob" => TreeEntryKind::Blob,
+            "tree" => TreeEntryKind::Tree,
+            "commit" => TreeEntryKind::Commit,
+            _ => return Err(()),
+        };
+        Ok(Self {
+            path: value.path,
+            kind,
+            size: value.size,
+        })
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct ContentResponse {
+    encoding: Option<String>,
+    content: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/model.rs
+++ b/src/model.rs
@@ -98,6 +98,14 @@ pub enum ForkMode {
     Only,
 }
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, ValueEnum, PartialEq, Eq, Default)]
+#[serde(rename_all = "kebab-case")]
+pub enum SearchPatternMode {
+    #[default]
+    Literal,
+    Regex,
+}
+
 impl ForkMode {
     pub fn qualifier(self) -> &'static str {
         match self {
@@ -186,6 +194,57 @@ pub struct SearchOutput {
 pub struct InspectOutput {
     pub host: String,
     pub repository: Repository,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum TreeEntryKind {
+    Blob,
+    Tree,
+    Commit,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TreeEntry {
+    pub path: String,
+    pub kind: TreeEntryKind,
+    pub size: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TreeOutput {
+    pub host: String,
+    pub repository: String,
+    pub reference: String,
+    pub truncated: bool,
+    pub total_count: usize,
+    pub items: Vec<TreeEntry>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CodeMatchLine {
+    pub line: usize,
+    pub text: String,
+    pub matched: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CodeMatch {
+    pub path: String,
+    pub line: usize,
+    pub lines: Vec<CodeMatchLine>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CodeSearchOutput {
+    pub host: String,
+    pub repository: String,
+    pub reference: String,
+    pub pattern: String,
+    pub mode: SearchPatternMode,
+    pub searched_files: usize,
+    pub skipped_files: usize,
+    pub total_count: usize,
+    pub items: Vec<CodeMatch>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/output.rs
+++ b/src/output.rs
@@ -1,5 +1,8 @@
 use crate::error::{AppError, AppResult};
-use crate::model::{ColorPreference, InspectOutput, OutputFormat, Repository, SearchOutput};
+use crate::model::{
+    CodeSearchOutput, ColorPreference, InspectOutput, OutputFormat, Repository, SearchOutput,
+    TreeEntryKind, TreeOutput,
+};
 use anstream::eprintln;
 use csv::Writer;
 use std::io::{self, IsTerminal, Write};
@@ -30,6 +33,32 @@ pub fn write_inspect(
         OutputFormat::Json => print_json(output, true),
         OutputFormat::Compact => print_json(output, false),
         OutputFormat::Csv => print_csv(std::slice::from_ref(&output.repository)),
+    }
+}
+
+pub fn write_tree(
+    output: &TreeOutput,
+    format: OutputFormat,
+    color: ColorPreference,
+) -> AppResult<()> {
+    match format {
+        OutputFormat::Pretty => print_pretty_tree(output, color),
+        OutputFormat::Json => print_json(output, true),
+        OutputFormat::Compact => print_json(output, false),
+        OutputFormat::Csv => print_tree_csv(output),
+    }
+}
+
+pub fn write_code_search(
+    output: &CodeSearchOutput,
+    format: OutputFormat,
+    color: ColorPreference,
+) -> AppResult<()> {
+    match format {
+        OutputFormat::Pretty => print_pretty_code_search(output, color),
+        OutputFormat::Json => print_json(output, true),
+        OutputFormat::Compact => print_json(output, false),
+        OutputFormat::Csv => print_code_csv(output),
     }
 }
 
@@ -90,6 +119,78 @@ fn print_pretty_inspect(output: &InspectOutput, color: ColorPreference) -> AppRe
         )
     })?;
     write_repo_detail(&mut stdout, &output.repository)?;
+    Ok(())
+}
+
+fn print_pretty_tree(output: &TreeOutput, color: ColorPreference) -> AppResult<()> {
+    let mut stdout = io::stdout().lock();
+    writeln!(
+        stdout,
+        "{}{}{}  ref={} entries={} truncated={}",
+        accent(color),
+        output.repository,
+        reset(color),
+        output.reference,
+        output.total_count,
+        output.truncated
+    )
+    .map_err(|err| {
+        AppError::with_detail("E_OUTPUT", "failed to write tree output", err.to_string())
+    })?;
+
+    for entry in &output.items {
+        let depth = entry.path.matches('/').count();
+        let name = entry.path.rsplit('/').next().unwrap_or(entry.path.as_str());
+        let marker = match entry.kind {
+            TreeEntryKind::Tree => "/",
+            TreeEntryKind::Blob => "",
+            TreeEntryKind::Commit => " @",
+        };
+        writeln!(stdout, "{}{}{}", "  ".repeat(depth + 1), name, marker).map_err(|err| {
+            AppError::with_detail("E_OUTPUT", "failed to write tree output", err.to_string())
+        })?;
+    }
+
+    Ok(())
+}
+
+fn print_pretty_code_search(output: &CodeSearchOutput, color: ColorPreference) -> AppResult<()> {
+    let mut stdout = io::stdout().lock();
+    writeln!(
+        stdout,
+        "{}{} matches{}  repo={} ref={} files={} skipped={}",
+        accent(color),
+        output.total_count,
+        reset(color),
+        output.repository,
+        output.reference,
+        output.searched_files,
+        output.skipped_files
+    )
+    .map_err(|err| {
+        AppError::with_detail("E_OUTPUT", "failed to write code output", err.to_string())
+    })?;
+
+    for item in &output.items {
+        writeln!(
+            stdout,
+            "\n{}{}:{}{}",
+            accent(color),
+            item.path,
+            item.line,
+            reset(color)
+        )
+        .map_err(|err| {
+            AppError::with_detail("E_OUTPUT", "failed to write code output", err.to_string())
+        })?;
+        for line in &item.lines {
+            let prefix = if line.matched { ">" } else { " " };
+            writeln!(stdout, "{prefix} {:>5} | {}", line.line, line.text).map_err(|err| {
+                AppError::with_detail("E_OUTPUT", "failed to write code output", err.to_string())
+            })?;
+        }
+    }
+
     Ok(())
 }
 
@@ -402,6 +503,61 @@ fn render_csv(repos: &[Repository]) -> AppResult<String> {
         AppError::with_detail("E_OUTPUT", "failed to decode CSV output", err.to_string())
     })?;
     Ok(raw)
+}
+
+fn print_tree_csv(output: &TreeOutput) -> AppResult<()> {
+    let mut writer = Writer::from_writer(Vec::new());
+    writer
+        .write_record(["path", "type", "size"])
+        .map_err(|err| {
+            AppError::with_detail("E_OUTPUT", "failed to write CSV header", err.to_string())
+        })?;
+    for entry in &output.items {
+        writer
+            .write_record([
+                entry.path.clone(),
+                format!("{:?}", entry.kind).to_lowercase(),
+                entry
+                    .size
+                    .map(|value| value.to_string())
+                    .unwrap_or_default(),
+            ])
+            .map_err(|err| {
+                AppError::with_detail("E_OUTPUT", "failed to write CSV row", err.to_string())
+            })?;
+    }
+    let bytes = writer.into_inner().map_err(|err| {
+        AppError::with_detail("E_OUTPUT", "failed to flush CSV output", err.to_string())
+    })?;
+    let raw = String::from_utf8(bytes).map_err(|err| {
+        AppError::with_detail("E_OUTPUT", "failed to decode CSV output", err.to_string())
+    })?;
+    write_line(raw.trim_end())
+}
+
+fn print_code_csv(output: &CodeSearchOutput) -> AppResult<()> {
+    let mut writer = Writer::from_writer(Vec::new());
+    writer
+        .write_record(["path", "line", "text"])
+        .map_err(|err| {
+            AppError::with_detail("E_OUTPUT", "failed to write CSV header", err.to_string())
+        })?;
+    for item in &output.items {
+        if let Some(line) = item.lines.iter().find(|line| line.matched) {
+            writer
+                .write_record([item.path.clone(), item.line.to_string(), line.text.clone()])
+                .map_err(|err| {
+                    AppError::with_detail("E_OUTPUT", "failed to write CSV row", err.to_string())
+                })?;
+        }
+    }
+    let bytes = writer.into_inner().map_err(|err| {
+        AppError::with_detail("E_OUTPUT", "failed to flush CSV output", err.to_string())
+    })?;
+    let raw = String::from_utf8(bytes).map_err(|err| {
+        AppError::with_detail("E_OUTPUT", "failed to decode CSV output", err.to_string())
+    })?;
+    write_line(raw.trim_end())
 }
 
 fn accent(color: ColorPreference) -> &'static str {

--- a/tests/cli-smoke.rs
+++ b/tests/cli-smoke.rs
@@ -109,8 +109,29 @@ fn serve(server: Server, stop_rx: Receiver<()>, request_count: Arc<AtomicUsize>)
                           "archived": false,
                           "is_template": false,
                           "fork": false,
+                          "default_branch": "main",
                           "open_issues_count": 4,
                           "owner": { "login": "example" }
+                        }"#,
+                    ),
+                    "/api/v3/repos/example/rocket/git/trees/main?recursive=1" => json_response(
+                        200,
+                        r#"{
+                          "truncated": false,
+                          "tree": [
+                            { "path": "README.md", "type": "blob", "size": 12 },
+                            { "path": "src", "type": "tree" },
+                            { "path": "src/lib.rs", "type": "blob", "size": 78 },
+                            { "path": "tests", "type": "tree" },
+                            { "path": "tests/cli.rs", "type": "blob", "size": 21 }
+                          ]
+                        }"#,
+                    ),
+                    "/api/v3/repos/example/rocket/contents/src/lib.rs?ref=main" => json_response(
+                        200,
+                        r#"{
+                          "encoding": "base64",
+                          "content": "cHViIGZuIHJ1bigpIHsKICAgIGxldCBjb21tYW5kID0gImdpdHF1YXJyeSI7CiAgICBwcmludGxuISgie2NvbW1hbmR9Iik7Cn0K"
                         }"#,
                     ),
                     "/api/v3/repos/example/rocket/contributors?per_page=1&anon=1" => {
@@ -398,6 +419,72 @@ fn inspect_json_returns_metadata_and_readme() {
         payload["repository"]["latest_release"]["tag_name"],
         "v1.2.3"
     );
+}
+
+#[test]
+fn tree_json_filters_by_glob_and_depth() {
+    let temp = TempDir::new().unwrap();
+    let (host, stop_tx, _) = start_fixture_server();
+
+    let output = base_command(&temp, &host)
+        .args([
+            "tree",
+            "example/rocket",
+            "--path",
+            "src/*",
+            "--depth",
+            "2",
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+
+    stop_tx.send(()).ok();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let payload: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(payload["reference"], "main");
+    assert_eq!(payload["items"].as_array().unwrap().len(), 1);
+    assert_eq!(payload["items"][0]["path"], "src/lib.rs");
+}
+
+#[test]
+fn code_json_searches_remote_file_content_with_context() {
+    let temp = TempDir::new().unwrap();
+    let (host, stop_tx, _) = start_fixture_server();
+
+    let output = base_command(&temp, &host)
+        .args([
+            "code",
+            "example/rocket",
+            "gitquarry",
+            "--path",
+            "src/*.rs",
+            "--context",
+            "1",
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+
+    stop_tx.send(()).ok();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let payload: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(payload["searched_files"], 1);
+    assert_eq!(payload["items"][0]["path"], "src/lib.rs");
+    assert_eq!(payload["items"][0]["line"], 2);
+    assert_eq!(payload["items"][0]["lines"].as_array().unwrap().len(), 3);
 }
 
 #[test]


### PR DESCRIPTION
**Summary**
- Add `gitquarry tree` for no-clone repository tree inspection with ref, glob, contains, depth, and structured output controls.
- Add `gitquarry code` for no-clone repository code search with literal/regex modes, path filters, context lines, limits, and max file size.
- Update command docs, output schemas, README, llms indexes, changelog, skill metadata, and release version to `0.1.7`.

**Verification**
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --locked`
- `npm pack --dry-run ./npm`
- `cargo package --locked`
- `cargo publish --locked --dry-run`