### PR TITLE
feat: add TOON output format

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,8 @@ jobs:
 
       - name: Cache Rust artifacts
         uses: Swatinem/rust-cache@v2
+        with:
+          cache-bin: false
 
       - name: Format
         run: cargo fmt --all -- --check
@@ -66,6 +68,8 @@ jobs:
 
       - name: Cache Rust artifacts
         uses: Swatinem/rust-cache@v2
+        with:
+          cache-bin: false
 
       - name: Test
         run: cargo test --locked

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -507,6 +507,7 @@ dependencies = [
  "tempfile",
  "tiny_http",
  "toml",
+ "toon",
  "url",
 ]
 
@@ -1583,6 +1584,16 @@ name = "toml_writer"
 version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+
+[[package]]
+name = "toon"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fa605a2aa68fefdedc9560bd765ce3ad89d45ac1d3ebad43724621098c9299a"
+dependencies = [
+ "regex",
+ "serde_json",
+]
 
 [[package]]
 name = "tower"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ reqwest = { version = "0.12.24", default-features = false, features = ["blocking
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"
 toml = "0.9.8"
+toon = "0.1.2"
 url = "2.5.7"
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ if you already use GitHub repository search and want a CLI that stays honest abo
 - native search stays native by default, including GitHub-style ordering and query semantics
 - discover mode is explicit, so broader candidate collection and reranking only happen when you opt in
 - README enrichment is off unless you request it
-- output modes are practical for both humans and scripts: `pretty`, `json`, `compact`, and `csv`
+- output modes are practical for both humans and scripts: `pretty`, `json`, `toon`, `compact`, and `csv`
 - auth handling is host-aware and works with secure storage, env overrides, or an explicit insecure fallback
 - failure modes are intended to be clear, narrow, and script-friendly
 
@@ -172,8 +172,11 @@ supported formats:
 
 - `pretty`
 - `json`
+- `toon`
 - `compact`
 - `csv`
+
+`toon` serializes the same structured payload as JSON using Token-Oriented Object Notation, which is useful when passing repository result sets into LLM context.
 
 root commands:
 
@@ -202,7 +205,7 @@ search-specific controls include:
 inspect-specific controls stay intentionally narrow:
 
 - `--readme`
-- `--format pretty|json|compact|csv`
+- `--format pretty|json|toon|compact|csv`
 - `--progress auto|on|off`
 
 tree-specific controls inspect remote repository paths without cloning:

--- a/docs/commands/code.mdx
+++ b/docs/commands/code.mdx
@@ -28,7 +28,7 @@ Use `--path`, `--limit`, and `--max-file-bytes` to keep broad searches bounded. 
 --context <N>
 --limit <N>
 --max-file-bytes <BYTES>
---format pretty|json|compact|csv
+--format pretty|json|toon|compact|csv
 --progress auto|on|off
 ```
 

--- a/docs/commands/inspect.mdx
+++ b/docs/commands/inspect.mdx
@@ -37,7 +37,7 @@ README content is optional and explicit.
 
 ```bash
 --readme
---format pretty|json|compact|csv
+--format pretty|json|toon|compact|csv
 --progress auto|on|off
 ```
 

--- a/docs/commands/search.mdx
+++ b/docs/commands/search.mdx
@@ -114,7 +114,7 @@ Examples:
 ## Output
 
 ```bash
---format pretty|json|compact|csv
+--format pretty|json|toon|compact|csv
 ```
 
 Examples:

--- a/docs/commands/tree.mdx
+++ b/docs/commands/tree.mdx
@@ -30,7 +30,7 @@ The output can be filtered before rendering:
 --path <GLOB>
 --contains <TEXT>
 --depth <N>
---format pretty|json|compact|csv
+--format pretty|json|toon|compact|csv
 --progress auto|on|off
 ```
 

--- a/docs/guides/output-and-scripting.mdx
+++ b/docs/guides/output-and-scripting.mdx
@@ -18,6 +18,7 @@ Supported formats:
 
 - `pretty`
 - `json`
+- `toon`
 - `compact`
 - `csv`
 
@@ -38,6 +39,15 @@ Pretty-printed structured output for tools and scripts:
 ```bash
 gitquarry search --format json "rust cli"
 gitquarry inspect rust-lang/rust --format json
+```
+
+### `toon`
+
+Token-efficient structured output for LLM context:
+
+```bash
+gitquarry search --format toon "rust cli"
+gitquarry inspect rust-lang/rust --format toon
 ```
 
 ### `compact`

--- a/docs/project/specification.mdx
+++ b/docs/project/specification.mdx
@@ -115,6 +115,7 @@ gitquarry search [OPTIONS] [QUERY]
 
 - `pretty` - default
 - `json`
+- `toon`
 - `compact`
 - `csv`
 
@@ -438,7 +439,7 @@ gitquarry inspect [OPTIONS] <OWNER/REPO>
 ### Inspect Flags
 
 - `--readme`
-- `--format pretty|json|compact|csv`
+- `--format pretty|json|toon|compact|csv`
 
 ## Source
 

--- a/docs/reference/config-and-credentials.mdx
+++ b/docs/reference/config-and-credentials.mdx
@@ -49,7 +49,7 @@ Saved config fields:
 
 Current enums:
 
-- `format`: `pretty|json|compact|csv`
+- `format`: `pretty|json|toon|compact|csv`
 - `progress`: `auto|on|off`
 - `color`: `auto|always|never`
 

--- a/docs/reference/output-contract.mdx
+++ b/docs/reference/output-contract.mdx
@@ -13,6 +13,7 @@ Supported formats:
 
 - `pretty`
 - `json`
+- `toon`
 - `compact`
 - `csv`
 
@@ -23,6 +24,10 @@ Human-first and concise.
 ### `json`
 
 Stable structured output intended for tools and scripts.
+
+### `toon`
+
+Token-efficient structured output intended for LLM context. It serializes the same data model as JSON.
 
 ### `compact`
 

--- a/docs/reference/output-schemas.mdx
+++ b/docs/reference/output-schemas.mdx
@@ -5,9 +5,9 @@ description: "See the exact JSON and CSV output shapes used by gitquarry search,
 
 # Output Schemas
 
-Gitquarry supports `pretty`, `json`, `compact`, and `csv`.
+Gitquarry supports `pretty`, `json`, `toon`, `compact`, and `csv`.
 
-This page documents the structured formats.
+This page documents the structured formats. `--format toon` serializes the same data model as JSON using Token-Oriented Object Notation, so the field contracts below apply to both JSON and TOON.
 
 ## Search JSON Shape
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -8,6 +8,7 @@ pub enum OutputFormat {
     #[default]
     Pretty,
     Json,
+    Toon,
     Compact,
     Csv,
 }

--- a/src/output.rs
+++ b/src/output.rs
@@ -18,6 +18,7 @@ pub fn write_search(
     match format {
         OutputFormat::Pretty => print_pretty_search(output, color),
         OutputFormat::Json => print_json(output, true),
+        OutputFormat::Toon => print_toon(output),
         OutputFormat::Compact => print_json(output, false),
         OutputFormat::Csv => print_csv(&output.items),
     }
@@ -31,6 +32,7 @@ pub fn write_inspect(
     match format {
         OutputFormat::Pretty => print_pretty_inspect(output, color),
         OutputFormat::Json => print_json(output, true),
+        OutputFormat::Toon => print_toon(output),
         OutputFormat::Compact => print_json(output, false),
         OutputFormat::Csv => print_csv(std::slice::from_ref(&output.repository)),
     }
@@ -44,6 +46,7 @@ pub fn write_tree(
     match format {
         OutputFormat::Pretty => print_pretty_tree(output, color),
         OutputFormat::Json => print_json(output, true),
+        OutputFormat::Toon => print_toon(output),
         OutputFormat::Compact => print_json(output, false),
         OutputFormat::Csv => print_tree_csv(output),
     }
@@ -57,6 +60,7 @@ pub fn write_code_search(
     match format {
         OutputFormat::Pretty => print_pretty_code_search(output, color),
         OutputFormat::Json => print_json(output, true),
+        OutputFormat::Toon => print_toon(output),
         OutputFormat::Compact => print_json(output, false),
         OutputFormat::Csv => print_code_csv(output),
     }
@@ -415,6 +419,17 @@ fn print_json<T: serde::Serialize>(value: &T, pretty: bool) -> AppResult<()> {
         AppError::with_detail("E_OUTPUT", "failed to serialize output", err.to_string())
     })?;
     write_line(&raw)
+}
+
+fn print_toon<T: serde::Serialize>(value: &T) -> AppResult<()> {
+    let value = serde_json::to_value(value).map_err(|err| {
+        AppError::with_detail(
+            "E_OUTPUT",
+            "failed to serialize TOON output",
+            err.to_string(),
+        )
+    })?;
+    write_line(&toon::encode(&value, None))
 }
 
 fn print_csv(repos: &[Repository]) -> AppResult<()> {

--- a/tests/cli-smoke.rs
+++ b/tests/cli-smoke.rs
@@ -918,6 +918,24 @@ fn compact_output_is_minified_json() {
 }
 
 #[test]
+fn toon_output_contains_tabular_repository_rows() {
+    let temp = TempDir::new().unwrap();
+    let (host, stop_tx, _) = start_fixture_server();
+
+    let output = base_command(&temp, &host)
+        .args(["search", "rust cli", "--format", "toon"])
+        .output()
+        .unwrap();
+
+    stop_tx.send(()).ok();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("items"));
+    assert!(stdout.contains("example/rocket"));
+}
+
+#[test]
 fn csv_output_contains_header_and_repository_row() {
     let temp = TempDir::new().unwrap();
     let (host, stop_tx, _) = start_fixture_server();


### PR DESCRIPTION
**Summary**
- Adds `--format toon` for structured gitquarry command output.
- Documents TOON in the README, command docs, output guide, schema/contract docs, and project spec.
- Uses the Rust `toon` crate to preserve the repo's MSRV constraints.

**Verification**
- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`