### PR TITLE
feat: update gitquarry mcp to protocol 2026-07-28

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is intentionally simple and does not depend on a release tool.
 
 ## Unreleased
 
+- Update `gitquarry mcp` to MCP `2026-07-28` and deprecate the standalone `gitquarry-mcp` wrapper.
+- Remove `gitquarry mcp --json-lines`; the server always writes one JSON-RPC response per line.
+
 ## [0.1.10]
 
 - Add search planning and probe output for path/code checks before running full discovery

--- a/docs/commands/mcp.mdx
+++ b/docs/commands/mcp.mdx
@@ -7,6 +7,24 @@ description: "Run gitquarry as a stdio Model Context Protocol server."
 
 Run a stdio JSON-RPC server that exposes gitquarry tools for agents.
 
+The standalone `gitquarry-mcp` wrapper is deprecated. Use this command so the
+MCP server and the CLI stay version-matched.
+
+## Protocol
+
+The server implements MCP `2026-07-28` over stdio:
+
+- messages are newline-delimited JSON-RPC 2.0 values
+- each request includes `_meta.io.modelcontextprotocol/protocolVersion` and
+  `_meta.io.modelcontextprotocol/clientCapabilities`
+- clients can call `server/discover` to learn the supported version and tools
+- the legacy `initialize` and `notifications/initialized` handshake is not
+  supported
+- `tools/list` and successful tool calls return `resultType: "complete"`
+
+Tool execution failures are returned as MCP tool results with `isError: true`.
+Malformed requests and unknown tools use JSON-RPC error responses.
+
 ## Synopsis
 
 ```bash
@@ -55,7 +73,9 @@ Restart Codex after changing MCP entries so the tool list is rediscovered.
 - `gitquarry_compare` - compare explicit repositories side by side. Accepts `repositories`, optional `readme`, and `tree_summary`.
 - `gitquarry_skill` - return the embedded gitquarry operator skill.
 
-The server reads one JSON-RPC request per stdin line and writes one JSON-RPC response per stdout line. This keeps the implementation dependency-light and easy to supervise from agent runners.
+The server reads one JSON-RPC request per stdin line and writes one JSON-RPC
+response per stdout line. This keeps the implementation dependency-light and
+easy to supervise from agent runners.
 
 ## Authentication
 

--- a/docs/project/specification.mdx
+++ b/docs/project/specification.mdx
@@ -528,11 +528,17 @@ gitquarry mcp
 ### Behavior
 
 - run a stdio JSON-RPC server for MCP clients
-- support `initialize`, `tools/list`, and `tools/call`
+- implement MCP `2026-07-28`
+- support `server/discover`, `tools/list`, and `tools/call`
+- require per-request protocol version and client capability metadata
+- reject unsupported versions with JSON-RPC error `-32022`
+- do not implement the legacy `initialize` handshake
 - expose search, inspect, tree, code, compare, and skill tools
-- return tool output as MCP text content
+- return `resultType` and server identity metadata on successful results
+- return cache hints on discovery and tool-list results
+- return tool execution failures as results with `isError: true`
 - use the same credential and host resolution as the CLI
-- keep diagnostics and errors out of tool content
+- keep diagnostics out of successful tool content; failure text appears only in `isError` results
 
 ## Source
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -36,6 +36,12 @@ use std::fs;
 use std::io::{self, BufRead, IsTerminal, Read, Write};
 use std::process::{Command as ProcessCommand, exit};
 
+const MCP_PROTOCOL_VERSION: &str = "2026-07-28";
+const MCP_PROTOCOL_VERSION_META: &str = "io.modelcontextprotocol/protocolVersion";
+const MCP_CLIENT_CAPABILITIES_META: &str = "io.modelcontextprotocol/clientCapabilities";
+const MCP_SERVER_INFO_META: &str = "io.modelcontextprotocol/serverInfo";
+const MCP_CACHE_TTL_MS: u64 = 300_000;
+
 pub fn main_entry() {
     if let Err(error) = run() {
         eprintln!("{error}");
@@ -534,8 +540,7 @@ fn config_command(config: &ConfigBundle, args: &ConfigArgs) -> AppResult<()> {
     }
 }
 
-fn run_mcp(cli: &Cli, args: &McpArgs) -> AppResult<()> {
-    let _json_lines = args.json_lines;
+fn run_mcp(cli: &Cli, _args: &McpArgs) -> AppResult<()> {
     let stdin = io::stdin();
     for line in stdin.lock().lines() {
         let line = line.map_err(|err| {
@@ -544,61 +549,229 @@ fn run_mcp(cli: &Cli, args: &McpArgs) -> AppResult<()> {
         if line.trim().is_empty() {
             continue;
         }
-        let request: serde_json::Value = serde_json::from_str(&line).map_err(|err| {
-            AppError::with_detail("E_MCP", "failed to parse JSON-RPC request", err.to_string())
-        })?;
-        let Some(id) = request.get("id").cloned() else {
+
+        let request: serde_json::Value = match serde_json::from_str(&line) {
+            Ok(request) => request,
+            Err(_) => {
+                write_mcp_response(&mcp_error(
+                    serde_json::Value::Null,
+                    -32700,
+                    "Parse error",
+                    None,
+                ))?;
+                continue;
+            }
+        };
+
+        let Some(request_object) = request.as_object() else {
+            write_mcp_response(&mcp_error(
+                serde_json::Value::Null,
+                -32600,
+                "Invalid Request",
+                None,
+            ))?;
             continue;
         };
-        let method = request
+        let Some(method) = request_object
             .get("method")
             .and_then(serde_json::Value::as_str)
-            .unwrap_or("");
-        let response = match method {
-            "initialize" => serde_json::json!({
-                "jsonrpc": "2.0",
-                "id": id,
-                "result": {
-                    "protocolVersion": "2024-11-05",
-                    "serverInfo": {
-                        "name": "gitquarry",
-                        "version": env!("CARGO_PKG_VERSION")
-                    },
-                    "capabilities": {"tools": {}}
-                }
-            }),
-            "tools/list" => serde_json::json!({
-                "jsonrpc": "2.0",
-                "id": id,
-                "result": {"tools": mcp_tool_definitions()}
-            }),
-            "tools/call" => match run_mcp_tool_call(cli, &request) {
-                Ok(result) => serde_json::json!({
-                    "jsonrpc": "2.0",
-                    "id": id,
-                    "result": result
-                }),
-                Err(error) => serde_json::json!({
-                    "jsonrpc": "2.0",
-                    "id": id,
-                    "error": {"code": -32000, "message": error.to_string()}
-                }),
-            },
-            _ => serde_json::json!({
-                "jsonrpc": "2.0",
-                "id": id,
-                "error": {"code": -32601, "message": format!("Method not found: {method}")}
-            }),
+        else {
+            write_mcp_response(&mcp_error(
+                request_object
+                    .get("id")
+                    .cloned()
+                    .unwrap_or(serde_json::Value::Null),
+                -32600,
+                "Invalid Request",
+                None,
+            ))?;
+            continue;
         };
-        write_line(&serde_json::to_string(&response).map_err(|err| {
-            AppError::with_detail(
-                "E_MCP",
-                "failed to serialize JSON-RPC response",
-                err.to_string(),
-            )
-        })?)?;
+        let Some(id) = request_object.get("id").cloned() else {
+            // Notifications do not receive responses. This also covers
+            // notifications/cancelled without adding state to the server.
+            continue;
+        };
+
+        let response = if !mcp_request_id_is_valid(&id) {
+            mcp_error(id, -32600, "Invalid Request", None)
+        } else {
+            handle_mcp_request(cli, &request, id, method)
+        };
+        write_mcp_response(&response)?;
     }
     Ok(())
+}
+
+fn handle_mcp_request(
+    cli: &Cli,
+    request: &serde_json::Value,
+    id: serde_json::Value,
+    method: &str,
+) -> serde_json::Value {
+    if request.get("jsonrpc").and_then(serde_json::Value::as_str) != Some("2.0") {
+        return mcp_error(id, -32600, "Invalid Request", None);
+    }
+
+    if method == "initialize" {
+        if let Some(version) = request
+            .get("params")
+            .and_then(serde_json::Value::as_object)
+            .and_then(|params| params.get("protocolVersion"))
+            .and_then(serde_json::Value::as_str)
+        {
+            return mcp_unsupported_version_error(id, version);
+        }
+        return mcp_error(id, -32601, "Method not found: initialize", None);
+    }
+    if method == "notifications/initialized" {
+        return mcp_error(
+            id,
+            -32601,
+            "Method not found: notifications/initialized",
+            None,
+        );
+    }
+
+    let version = match mcp_request_version(request) {
+        Ok(version) => version,
+        Err(message) => return mcp_error(id, -32602, message, None),
+    };
+    if version != MCP_PROTOCOL_VERSION {
+        return mcp_unsupported_version_error(id, &version);
+    }
+
+    match method {
+        "server/discover" => mcp_result(id, mcp_discover_result()),
+        "tools/list" => mcp_result(id, mcp_tools_list_result()),
+        "tools/call" => match run_mcp_tool_call(cli, request) {
+            Ok(text) => mcp_result(id, mcp_tool_result(text, false)),
+            Err(McpToolCallError::InvalidParams(message)) => mcp_error(id, -32602, message, None),
+            Err(McpToolCallError::Execution(message)) => {
+                mcp_result(id, mcp_tool_result(message, true))
+            }
+            Err(McpToolCallError::Internal(message)) => mcp_error(id, -32603, message, None),
+        },
+        _ => mcp_error(id, -32601, format!("Method not found: {method}"), None),
+    }
+}
+
+fn write_mcp_response(response: &serde_json::Value) -> AppResult<()> {
+    let serialized = serde_json::to_string(response).map_err(|err| {
+        AppError::with_detail(
+            "E_MCP",
+            "failed to serialize JSON-RPC response",
+            err.to_string(),
+        )
+    })?;
+    write_line(&serialized)
+}
+
+fn mcp_request_version(request: &serde_json::Value) -> Result<String, String> {
+    let params = request
+        .get("params")
+        .and_then(serde_json::Value::as_object)
+        .ok_or_else(|| {
+            format!(
+                "request params must include _meta with {MCP_PROTOCOL_VERSION_META} and {MCP_CLIENT_CAPABILITIES_META}"
+            )
+        })?;
+    let meta = params
+        .get("_meta")
+        .and_then(serde_json::Value::as_object)
+        .ok_or_else(|| {
+            format!(
+                "request metadata must include {MCP_PROTOCOL_VERSION_META} and {MCP_CLIENT_CAPABILITIES_META}"
+            )
+        })?;
+    let version = meta
+        .get(MCP_PROTOCOL_VERSION_META)
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| format!("request metadata must include {MCP_PROTOCOL_VERSION_META}"))?;
+    if !meta
+        .get(MCP_CLIENT_CAPABILITIES_META)
+        .is_some_and(serde_json::Value::is_object)
+    {
+        return Err(format!(
+            "request metadata must include {MCP_CLIENT_CAPABILITIES_META} as an object"
+        ));
+    }
+    Ok(version.to_string())
+}
+
+fn mcp_request_id_is_valid(id: &serde_json::Value) -> bool {
+    id.is_string() || id.as_i64().is_some() || id.as_u64().is_some()
+}
+
+fn mcp_result(id: serde_json::Value, result: serde_json::Value) -> serde_json::Value {
+    serde_json::json!({"jsonrpc": "2.0", "id": id, "result": result})
+}
+
+fn mcp_error(
+    id: serde_json::Value,
+    code: i64,
+    message: impl Into<String>,
+    data: Option<serde_json::Value>,
+) -> serde_json::Value {
+    let mut error = serde_json::json!({
+        "code": code,
+        "message": message.into()
+    });
+    if let Some(data) = data {
+        error["data"] = data;
+    }
+    serde_json::json!({"jsonrpc": "2.0", "id": id, "error": error})
+}
+
+fn mcp_unsupported_version_error(id: serde_json::Value, requested: &str) -> serde_json::Value {
+    mcp_error(
+        id,
+        -32022,
+        "Unsupported protocol version",
+        Some(serde_json::json!({
+            "supported": [MCP_PROTOCOL_VERSION],
+            "requested": requested
+        })),
+    )
+}
+
+fn mcp_server_meta() -> serde_json::Value {
+    serde_json::json!({
+        MCP_SERVER_INFO_META: {
+            "name": "gitquarry",
+            "version": env!("CARGO_PKG_VERSION")
+        }
+    })
+}
+
+fn mcp_discover_result() -> serde_json::Value {
+    serde_json::json!({
+        "resultType": "complete",
+        "supportedVersions": [MCP_PROTOCOL_VERSION],
+        "capabilities": {"tools": {}},
+        "ttlMs": MCP_CACHE_TTL_MS,
+        "cacheScope": "public",
+        "_meta": mcp_server_meta()
+    })
+}
+
+fn mcp_tools_list_result() -> serde_json::Value {
+    serde_json::json!({
+        "resultType": "complete",
+        "tools": mcp_tool_definitions(),
+        "ttlMs": MCP_CACHE_TTL_MS,
+        "cacheScope": "public",
+        "_meta": mcp_server_meta()
+    })
+}
+
+fn mcp_tool_result(text: String, is_error: bool) -> serde_json::Value {
+    serde_json::json!({
+        "resultType": "complete",
+        "content": [{"type": "text", "text": text}],
+        "isError": is_error,
+        "_meta": mcp_server_meta()
+    })
 }
 
 fn mcp_tool_definitions() -> serde_json::Value {
@@ -707,25 +880,147 @@ fn mcp_tool_definitions() -> serde_json::Value {
     ])
 }
 
-fn run_mcp_tool_call(cli: &Cli, request: &serde_json::Value) -> AppResult<serde_json::Value> {
+fn validate_mcp_tool_arguments(name: &str, arguments: &serde_json::Value) -> Result<(), String> {
+    // Validate against the schema advertised by tools/list so execution cannot
+    // silently drop malformed values or accept fields clients were not told about.
+    let definitions = mcp_tool_definitions();
+    let tool = definitions
+        .as_array()
+        .and_then(|tools| {
+            tools
+                .iter()
+                .find(|tool| tool.get("name").and_then(serde_json::Value::as_str) == Some(name))
+        })
+        .ok_or_else(|| format!("unknown tool `{name}`"))?;
+    let schema = tool
+        .get("inputSchema")
+        .ok_or_else(|| format!("tool `{name}` has no input schema"))?;
+    let properties = schema
+        .get("properties")
+        .and_then(serde_json::Value::as_object)
+        .ok_or_else(|| format!("tool `{name}` has an invalid input schema"))?;
+    let arguments = arguments
+        .as_object()
+        .ok_or_else(|| "tool arguments must be an object".to_string())?;
+
+    if schema.get("additionalProperties") == Some(&serde_json::Value::Bool(false)) {
+        if let Some(unknown) = arguments
+            .keys()
+            .find(|argument| !properties.contains_key(argument.as_str()))
+        {
+            return Err(format!("unknown argument `{unknown}` for tool `{name}`"));
+        }
+    }
+
+    if let Some(required) = schema.get("required").and_then(serde_json::Value::as_array) {
+        for required_name in required.iter().filter_map(serde_json::Value::as_str) {
+            if !arguments.contains_key(required_name) {
+                return Err(format!(
+                    "missing required argument `{required_name}` for tool `{name}`"
+                ));
+            }
+        }
+    }
+
+    for (argument_name, value) in arguments {
+        if let Some(argument_schema) = properties.get(argument_name) {
+            validate_mcp_schema_value(value, argument_schema, argument_name)?;
+        }
+    }
+    Ok(())
+}
+
+fn validate_mcp_schema_value(
+    value: &serde_json::Value,
+    schema: &serde_json::Value,
+    path: &str,
+) -> Result<(), String> {
+    let schema_type = schema
+        .get("type")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| format!("tool schema is missing a type for `{path}`"))?;
+    let valid_type = match schema_type {
+        "string" => value.is_string(),
+        "integer" => value.as_i64().is_some() || value.as_u64().is_some(),
+        "boolean" => value.is_boolean(),
+        "array" => value.is_array(),
+        _ => {
+            return Err(format!(
+                "unsupported tool schema type `{schema_type}` for `{path}`"
+            ));
+        }
+    };
+    if !valid_type {
+        return Err(format!("argument `{path}` must be a {schema_type}"));
+    }
+
+    if let Some(enum_values) = schema.get("enum").and_then(serde_json::Value::as_array)
+        && !enum_values.iter().any(|option| option == value)
+    {
+        return Err(format!("argument `{path}` has an unsupported value"));
+    }
+
+    if let Some(minimum) = schema.get("minimum").and_then(serde_json::Value::as_u64) {
+        let below_minimum = if let Some(value) = value.as_i64() {
+            value < 0 || (value as u64) < minimum
+        } else {
+            value.as_u64().is_none_or(|value| value < minimum)
+        };
+        if below_minimum {
+            return Err(format!("argument `{path}` must be at least {minimum}"));
+        }
+    }
+
+    if let Some(array) = value.as_array() {
+        if let Some(min_items) = schema.get("minItems").and_then(serde_json::Value::as_u64)
+            && (array.len() as u64) < min_items
+        {
+            return Err(format!(
+                "argument `{path}` must contain at least {min_items} items"
+            ));
+        }
+        if let Some(item_schema) = schema.get("items") {
+            for (index, item) in array.iter().enumerate() {
+                validate_mcp_schema_value(item, item_schema, &format!("{path}[{index}]"))?;
+            }
+        }
+    }
+    Ok(())
+}
+
+enum McpToolCallError {
+    InvalidParams(String),
+    Execution(String),
+    Internal(String),
+}
+
+fn run_mcp_tool_call(cli: &Cli, request: &serde_json::Value) -> Result<String, McpToolCallError> {
     let params = request
         .get("params")
-        .cloned()
-        .unwrap_or_else(|| serde_json::json!({}));
+        .and_then(serde_json::Value::as_object)
+        .ok_or_else(|| McpToolCallError::InvalidParams("params must be an object".to_string()))?;
     let name = params
         .get("name")
         .and_then(serde_json::Value::as_str)
-        .unwrap_or("");
+        .filter(|name| !name.trim().is_empty())
+        .ok_or_else(|| McpToolCallError::InvalidParams("missing tool name".to_string()))?;
     let arguments = params
         .get("arguments")
         .cloned()
         .unwrap_or_else(|| serde_json::json!({}));
-    let text = match name {
-        "gitquarry_search" => run_gitquarry_tool(cli, mcp_search_args(&arguments)?)?,
-        "gitquarry_inspect" => run_gitquarry_tool(cli, mcp_inspect_args(&arguments)?)?,
-        "gitquarry_tree" => run_gitquarry_tool(cli, mcp_tree_args(&arguments)?)?,
-        "gitquarry_code" => run_gitquarry_tool(cli, mcp_code_args(&arguments)?)?,
-        "gitquarry_compare" => run_gitquarry_tool(cli, mcp_compare_args(&arguments)?)?,
+    if !arguments.is_object() {
+        return Err(McpToolCallError::InvalidParams(
+            "tool arguments must be an object".to_string(),
+        ));
+    }
+    validate_mcp_tool_arguments(name, &arguments).map_err(McpToolCallError::InvalidParams)?;
+
+    match name {
+        "gitquarry_search" => run_mcp_cli_tool(cli, mcp_search_args(&arguments)),
+        "gitquarry_inspect" => run_mcp_cli_tool(cli, mcp_inspect_args(&arguments)),
+        "gitquarry_tree" => run_mcp_cli_tool(cli, mcp_tree_args(&arguments)),
+        "gitquarry_code" => run_mcp_cli_tool(cli, mcp_code_args(&arguments)),
+        "gitquarry_compare" => run_mcp_cli_tool(cli, mcp_compare_args(&arguments)),
         "gitquarry_skill" => {
             let full = arguments
                 .get("full")
@@ -737,15 +1032,18 @@ fn run_mcp_tool_call(cli: &Cli, request: &serde_json::Value) -> AppResult<serde_
                 crate::agent::skill_content(crate::agent::GITQUARRY_SKILL)
             }
             .ok_or_else(|| {
-                AppError::new("E_SKILL_UNKNOWN", "embedded gitquarry skill is unavailable")
-            })?
+                McpToolCallError::Internal("embedded gitquarry skill is unavailable".to_string())
+            })
         }
-        _ => format!("unsupported tool `{name}`"),
-    };
+        _ => Err(McpToolCallError::InvalidParams(format!(
+            "unknown tool `{name}`"
+        ))),
+    }
+}
 
-    Ok(serde_json::json!({
-        "content": [{"type": "text", "text": text}]
-    }))
+fn run_mcp_cli_tool(cli: &Cli, args: AppResult<Vec<String>>) -> Result<String, McpToolCallError> {
+    let args = args.map_err(|error| McpToolCallError::InvalidParams(error.to_string()))?;
+    run_gitquarry_tool(cli, args).map_err(|error| McpToolCallError::Execution(error.to_string()))
 }
 
 fn run_gitquarry_tool(cli: &Cli, mut args: Vec<String>) -> AppResult<String> {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -447,11 +447,7 @@ pub struct RecipeRunArgs {
 }
 
 #[derive(Debug, Args, Clone)]
-pub struct McpArgs {
-    /// Print one JSON-RPC response per line.
-    #[arg(long)]
-    pub json_lines: bool,
-}
+pub struct McpArgs {}
 
 #[derive(Debug, Args, Clone)]
 pub struct SourcePathArgs {

--- a/tests/cli-smoke.rs
+++ b/tests/cli-smoke.rs
@@ -287,6 +287,17 @@ fn local_command(temp: &TempDir) -> Command {
     command
 }
 
+fn mcp_meta() -> serde_json::Value {
+    serde_json::json!({
+        "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+        "io.modelcontextprotocol/clientCapabilities": {},
+        "io.modelcontextprotocol/clientInfo": {
+            "name": "gitquarry-test",
+            "version": "1.0.0"
+        }
+    })
+}
+
 fn host_key(host: &str) -> String {
     host.trim_start_matches("http://")
         .trim_start_matches("https://")
@@ -502,13 +513,23 @@ fn mcp_lists_gitquarry_tools() {
         writeln!(
             stdin,
             "{}",
-            serde_json::json!({"jsonrpc":"2.0","id":1,"method":"initialize"})
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "server/discover",
+                "params": {"_meta": mcp_meta()}
+            })
         )
         .unwrap();
         writeln!(
             stdin,
             "{}",
-            serde_json::json!({"jsonrpc":"2.0","id":2,"method":"tools/list"})
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "tools/list",
+                "params": {"_meta": mcp_meta()}
+            })
         )
         .unwrap();
     }
@@ -525,10 +546,129 @@ fn mcp_lists_gitquarry_tools() {
         .lines()
         .map(|line| serde_json::from_str::<serde_json::Value>(line).unwrap())
         .collect::<Vec<_>>();
-    assert_eq!(responses[0]["result"]["serverInfo"]["name"], "gitquarry");
+    assert_eq!(responses[0]["result"]["supportedVersions"][0], "2026-07-28");
+    assert_eq!(responses[0]["result"]["resultType"], "complete");
+    assert_eq!(
+        responses[0]["result"]["_meta"]["io.modelcontextprotocol/serverInfo"]["name"],
+        "gitquarry"
+    );
+    assert_eq!(responses[1]["result"]["resultType"], "complete");
+    assert_eq!(responses[1]["result"]["cacheScope"], "public");
+    assert_eq!(responses[1]["result"]["ttlMs"], 300_000);
     let tools = responses[1]["result"]["tools"].as_array().unwrap();
     assert!(tools.iter().any(|tool| tool["name"] == "gitquarry_search"));
     assert!(tools.iter().any(|tool| tool["name"] == "gitquarry_skill"));
+}
+
+#[test]
+fn mcp_rejects_legacy_initialize() {
+    let temp = TempDir::new().unwrap();
+    let mut command = local_command(&temp);
+    command
+        .arg("mcp")
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped());
+    let mut child = command.spawn().unwrap();
+    {
+        let stdin = child.stdin.as_mut().unwrap();
+        writeln!(
+            stdin,
+            "{}",
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2025-11-25",
+                    "capabilities": {},
+                    "clientInfo": {"name": "legacy-client", "version": "1.0.0"}
+                }
+            })
+        )
+        .unwrap();
+    }
+    drop(child.stdin.take());
+    let output = child.wait_with_output().unwrap();
+
+    assert!(output.status.success());
+    let response: serde_json::Value =
+        serde_json::from_str(String::from_utf8(output.stdout).unwrap().trim()).unwrap();
+    assert_eq!(response["error"]["code"], -32022);
+    assert_eq!(response["error"]["data"]["requested"], "2025-11-25");
+    assert_eq!(response["error"]["data"]["supported"][0], "2026-07-28");
+}
+
+#[test]
+fn mcp_rejects_missing_request_metadata() {
+    let temp = TempDir::new().unwrap();
+    let mut command = local_command(&temp);
+    command
+        .arg("mcp")
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped());
+    let mut child = command.spawn().unwrap();
+    {
+        let stdin = child.stdin.as_mut().unwrap();
+        writeln!(
+            stdin,
+            "{}",
+            serde_json::json!({"jsonrpc":"2.0","id":1,"method":"tools/list"})
+        )
+        .unwrap();
+    }
+    drop(child.stdin.take());
+    let output = child.wait_with_output().unwrap();
+
+    assert!(output.status.success());
+    let response: serde_json::Value =
+        serde_json::from_str(String::from_utf8(output.stdout).unwrap().trim()).unwrap();
+    assert_eq!(response["error"]["code"], -32602);
+    assert!(
+        response["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("clientCapabilities")
+    );
+}
+
+#[test]
+fn mcp_rejects_unsupported_protocol_version() {
+    let temp = TempDir::new().unwrap();
+    let mut command = local_command(&temp);
+    command
+        .arg("mcp")
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped());
+    let mut child = command.spawn().unwrap();
+    {
+        let stdin = child.stdin.as_mut().unwrap();
+        let mut meta = mcp_meta();
+        meta["io.modelcontextprotocol/protocolVersion"] =
+            serde_json::Value::String("2025-11-25".to_string());
+        writeln!(
+            stdin,
+            "{}",
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "server/discover",
+                "params": {"_meta": meta}
+            })
+        )
+        .unwrap();
+    }
+    drop(child.stdin.take());
+    let output = child.wait_with_output().unwrap();
+
+    assert!(output.status.success());
+    let response: serde_json::Value =
+        serde_json::from_str(String::from_utf8(output.stdout).unwrap().trim()).unwrap();
+    assert_eq!(response["error"]["code"], -32022);
+    assert_eq!(response["error"]["data"]["requested"], "2025-11-25");
+    assert_eq!(response["error"]["data"]["supported"][0], "2026-07-28");
 }
 
 #[test]
@@ -552,6 +692,7 @@ fn mcp_search_tool_calls_gitquarry_search() {
                 "id": 1,
                 "method": "tools/call",
                 "params": {
+                    "_meta": mcp_meta(),
                     "name": "gitquarry_search",
                     "arguments": {
                         "query": "rust cli",
@@ -574,9 +715,167 @@ fn mcp_search_tool_calls_gitquarry_search() {
     assert_eq!(request_count.load(Ordering::SeqCst), 1);
     let response: serde_json::Value =
         serde_json::from_str(String::from_utf8(output.stdout).unwrap().trim()).unwrap();
+    assert_eq!(response["result"]["resultType"], "complete");
+    assert_eq!(response["result"]["isError"], false);
+    assert_eq!(
+        response["result"]["_meta"]["io.modelcontextprotocol/serverInfo"]["name"],
+        "gitquarry"
+    );
     let text = response["result"]["content"][0]["text"].as_str().unwrap();
     let payload: serde_json::Value = serde_json::from_str(text).unwrap();
     assert_eq!(payload["items"][0]["full_name"], "example/rocket");
+}
+
+#[test]
+fn mcp_unknown_tool_is_a_protocol_error() {
+    let temp = TempDir::new().unwrap();
+    let mut command = local_command(&temp);
+    command
+        .arg("mcp")
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped());
+    let mut child = command.spawn().unwrap();
+    {
+        let stdin = child.stdin.as_mut().unwrap();
+        writeln!(
+            stdin,
+            "{}",
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/call",
+                "params": {
+                    "_meta": mcp_meta(),
+                    "name": "missing_tool",
+                    "arguments": {}
+                }
+            })
+        )
+        .unwrap();
+    }
+    drop(child.stdin.take());
+    let output = child.wait_with_output().unwrap();
+
+    assert!(output.status.success());
+    let response: serde_json::Value =
+        serde_json::from_str(String::from_utf8(output.stdout).unwrap().trim()).unwrap();
+    assert_eq!(response["error"]["code"], -32602);
+}
+
+#[test]
+fn mcp_rejects_invalid_tool_arguments() {
+    let temp = TempDir::new().unwrap();
+    let mut command = local_command(&temp);
+    command
+        .arg("mcp")
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped());
+    let mut child = command.spawn().unwrap();
+    {
+        let stdin = child.stdin.as_mut().unwrap();
+        for (id, arguments) in [
+            (1, serde_json::json!({"query": "rust cli", "limit": "one"})),
+            (
+                2,
+                serde_json::json!({"query": "rust cli", "unexpected": true}),
+            ),
+            (3, serde_json::json!({"query": "rust cli", "limit": -1})),
+        ] {
+            writeln!(
+                stdin,
+                "{}",
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": id,
+                    "method": "tools/call",
+                    "params": {
+                        "_meta": mcp_meta(),
+                        "name": "gitquarry_search",
+                        "arguments": arguments
+                    }
+                })
+            )
+            .unwrap();
+        }
+    }
+    drop(child.stdin.take());
+    let output = child.wait_with_output().unwrap();
+
+    assert!(output.status.success());
+    let responses = String::from_utf8(output.stdout)
+        .unwrap()
+        .lines()
+        .map(|line| serde_json::from_str::<serde_json::Value>(line).unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(responses.len(), 3);
+    assert_eq!(responses[0]["error"]["code"], -32602);
+    assert!(
+        responses[0]["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("limit")
+    );
+    assert_eq!(responses[1]["error"]["code"], -32602);
+    assert!(
+        responses[1]["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("unexpected")
+    );
+    assert_eq!(responses[2]["error"]["code"], -32602);
+    assert!(
+        responses[2]["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("limit")
+    );
+}
+
+#[test]
+fn mcp_tool_failure_is_returned_as_a_tool_result_error() {
+    let temp = TempDir::new().unwrap();
+    let host = "http://127.0.0.1:1/api/v3";
+    let mut command = base_command(&temp, host);
+    command
+        .arg("mcp")
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped());
+    let mut child = command.spawn().unwrap();
+    {
+        let stdin = child.stdin.as_mut().unwrap();
+        writeln!(
+            stdin,
+            "{}",
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/call",
+                "params": {
+                    "_meta": mcp_meta(),
+                    "name": "gitquarry_search",
+                    "arguments": {"query": "rust cli"}
+                }
+            })
+        )
+        .unwrap();
+    }
+    drop(child.stdin.take());
+    let output = child.wait_with_output().unwrap();
+
+    assert!(output.status.success());
+    let response: serde_json::Value =
+        serde_json::from_str(String::from_utf8(output.stdout).unwrap().trim()).unwrap();
+    assert_eq!(response["result"]["resultType"], "complete");
+    assert_eq!(response["result"]["isError"], true);
+    assert!(
+        response["result"]["content"][0]["text"]
+            .as_str()
+            .unwrap()
+            .contains("failed")
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- update the built-in `gitquarry mcp` command to MCP `2026-07-28`
- replace the legacy initialize flow with per-request metadata and `server/discover`
- return modern result envelopes, cache hints, server metadata, and correct tool errors
- deprecate the standalone `gitquarry-mcp` wrapper in the documentation

## Verification

- [x] cargo fmt --all -- --check
- [x] cargo clippy --locked --all-targets --all-features -- -D warnings
- [x] cargo test --locked
- [x] docs updated

## Notes

this is a current-state protocol cut. the server supports `2026-07-28` only.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR updates the built-in stdio server to MCP `2026-07-28` and replaces the legacy initialization flow with request-scoped protocol metadata.

- Adds `server/discover`, modern result envelopes, server metadata, cache hints, and protocol-version errors.
- Validates tool arguments against advertised schemas and distinguishes invalid parameters, execution failures, and internal errors.
- Removes `mcp --json-lines`, updates protocol documentation, and expands CLI smoke coverage.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/app.rs | Implements the MCP protocol transition, request validation, discovery responses, schema-based tool argument validation, and modern result/error envelopes; both previously reported validation defects are corrected. |
| src/cli.rs | Removes the obsolete `--json-lines` option while retaining the built-in MCP subcommand. |
| tests/cli-smoke.rs | Updates MCP smoke requests for per-request metadata and adds coverage for discovery, unsupported versions, malformed arguments, unknown tools, and execution failures. |
| docs/commands/mcp.mdx | Documents the MCP `2026-07-28` transport, metadata requirements, discovery flow, result envelopes, and wrapper deprecation. |
| docs/project/specification.mdx | Aligns the project specification with the new current-state MCP contract. |

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant MCP as gitquarry mcp
    participant Tool as Gitquarry CLI tool
    Client->>MCP: server/discover + request metadata
    MCP-->>Client: supported version, tools capability, cache hints
    Client->>MCP: tools/call + metadata + arguments
    MCP->>MCP: Validate protocol and tool schema
    alt Valid arguments
        MCP->>Tool: Execute translated CLI arguments
        Tool-->>MCP: Output or execution failure
        MCP-->>Client: Complete tool result
    else Invalid arguments
        MCP-->>Client: JSON-RPC -32602
    end
```

<sub>Reviews (4): Last reviewed commit: ["feat: update gitquarry mcp to protocol 2..."](https://github.com/microck/gitquarry/commit/f395c3595219d24d29c905bf56bc428bc8ddad3e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53320592)</sub>

<!-- /greptile_comment -->