### PR TITLE
fix(ci): publish npm releases with verified auth

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,6 +66,17 @@ jobs:
         uses: actions/setup-node@v6.0.0
         with:
           node-version: 24
+          registry-url: https://registry.npmjs.org
+
+      - name: Verify npm credentials
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          if [ -z "${NODE_AUTH_TOKEN:-}" ]; then
+            echo "::error::NPM_TOKEN is not configured for the release workflow."
+            exit 1
+          fi
+          npm whoami --registry=https://registry.npmjs.org
 
       - name: Validate npm wrapper package
         run: npm pack --dry-run ./npm
@@ -217,27 +228,8 @@ jobs:
           node-version: 24
           registry-url: https://registry.npmjs.org
 
-      - name: Check npm token availability
-        id: token-check
-        run: |
-          if [ -n "${NODE_AUTH_TOKEN:-}" ]; then
-            echo "has_token=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "has_token=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Explain skipped npm publish
-        if: steps.token-check.outputs.has_token != 'true'
-        run: echo "NPM_TOKEN is not configured; skipping npm publish."
-
       - name: Publish to npm
-        if: steps.token-check.outputs.has_token == 'true'
-        run: |
-          if npm publish ./npm --access public --provenance; then
-            exit 0
-          fi
-
-          echo "::warning::npm publish failed. GitHub release assets are already published; fix NPM_TOKEN/package permissions and publish the npm wrapper manually if needed."
+        run: npm publish ./npm --access public --provenance
 
   publish-release:
     name: Publish release

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -4,7 +4,7 @@ Use this when cutting a new `gitquarry` release.
 
 ## Goal
 
-Ship one version across GitHub release assets, npm, downstream packaging repos, the AUR, public documentation, and crates.io when registry credentials are configured.
+Ship one version across GitHub release assets, npm, downstream packaging repos, the AUR, and public documentation. Publish crates.io when its registry credential is configured.
 
 ## Preflight
 
@@ -12,14 +12,14 @@ Ship one version across GitHub release assets, npm, downstream packaging repos, 
 2. Make sure `main` is green before tagging.
 3. Pick the release version `X.Y.Z`.
 4. Confirm release automation credentials are present:
+   - `NPM_TOKEN` GitHub Actions secret for the required npm publication
    - `CARGO_REGISTRY_TOKEN` GitHub Actions secret for crates.io publishing
    - `GITQUARRY_TOKEN` GitHub Actions secret for live smoke checks
 5. Confirm `CHANGELOG.md` includes the user-facing notes for the release.
 6. Be ready to update downstream packaging repos after the GitHub release completes:
    - `Microck/homebrew-gitquarry`
    - `Microck/scoop-gitquarry`
-7. Confirm npm publish access if you want the release workflow to publish the Node wrapper automatically:
-   - `NPM_TOKEN` GitHub Actions secret
+7. Confirm npm publish access before tagging. The release workflow requires `NPM_TOKEN`, verifies it with `npm whoami`, and fails the release job if npm publication cannot complete.
 8. Confirm AUR SSH access for `aur@aur.archlinux.org` if you plan to publish the Arch package immediately after the release.
 
 ## Update release metadata
@@ -74,7 +74,8 @@ git push origin vX.Y.Z
 - creates a source tarball for packaging workflows
 - generates `SHA256SUMS`
 - creates the GitHub release and uploads the packaged artifacts
-- publishes the npm wrapper when `NPM_TOKEN` is configured
+- verifies `NPM_TOKEN` with `npm whoami`
+- publishes the npm wrapper and fails the release job if publication cannot complete
 
 ## Post-tag checks
 
@@ -85,6 +86,7 @@ Verify all public release surfaces after the workflows finish:
    - confirm the release includes the per-target archives, the source tarball, and `SHA256SUMS`
 2. Release workflow health
    - `gh run list --workflow Release -R Microck/gitquarry --limit 5`
+   - confirm the `Publish npm package` job passed; npm publication is required for a complete release
 3. Downstream packaging repos
    - update `Microck/homebrew-gitquarry/Formula/gitquarry.rb` to the new version and hashes
    - update `Microck/scoop-gitquarry/bucket/gitquarry.json` to the new version and Windows hash
@@ -105,6 +107,7 @@ scoop install gitquarry
 5. npm
    - `npm view gitquarry version dist.tarball`
    - confirm the published version matches `X.Y.Z`
+   - if npm still shows an older version, stop the release follow-up and fix `NPM_TOKEN` or package access before announcing the release
 6. AUR
    - push the updated `PKGBUILD` and `.SRCINFO` to `ssh://aur@aur.archlinux.org/gitquarry.git`
    - verify `https://aur.archlinux.org/packages/gitquarry/` reflects the new version
@@ -174,6 +177,23 @@ cargo publish --locked
 ```
 
 3. Confirm crates.io shows the new version before announcing the release.
+
+### GitHub release exists but npm publish failed
+
+1. Verify the repository `NPM_TOKEN` secret belongs to an npm account that can publish `gitquarry`.
+2. Verify the package version is not already published:
+
+```bash
+npm view gitquarry version dist-tags
+```
+
+3. Publish the matching wrapper from a trusted environment:
+
+```bash
+npm publish ./npm --access public
+```
+
+4. Confirm npm shows the release version before announcing it.
 
 ### crates.io is published but GitHub assets are wrong
 


### PR DESCRIPTION
## Summary

- verify npm credentials before publishing release packages
- fail the release job when `NPM_TOKEN` is missing or invalid
- surface npm publication failures as actionable CI failures

## Verification

- [x] npm pack --dry-run ./npm
- [x] release workflow YAML parsed
- [x] published `gitquarry@0.2.0` with the local npm credential

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR makes npm authentication and publication mandatory for releases and updates the release guidance accordingly.
- Verifies `NPM_TOKEN` against the npm registry before building release artifacts.
- Propagates npm publication failures instead of skipping or suppressing them.
- Documents required credentials, post-release verification, and manual recovery.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/release.yml | Adds blocking npm credential verification and makes npm publication failures fail the release workflow. |
| docs/release-runbook.md | Aligns release prerequisites, verification steps, and recovery guidance with mandatory npm publication. |

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant V as Verify release job
    participant N as npm registry
    participant B as Build and GitHub release
    participant P as Publish npm job
    V->>N: npm whoami using NPM_TOKEN
    N-->>V: Authentication result
    V->>V: Validate wrapper package
    V-->>B: Verification passed
    B-->>P: Release artifacts published
    P->>N: npm publish with provenance
    N-->>P: Publication result
```

<sub>Reviews (3): Last reviewed commit: ["fix(ci): preflight npm auth before relea..."](https://github.com/microck/gitquarry/commit/0fbaa258ef8ffc4bbcd0eac7783f994606801fec) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53367779)</sub>

<!-- /greptile_comment -->